### PR TITLE
Exclude Now 1.0 deployments

### DIFF
--- a/ttfb.sql
+++ b/ttfb.sql
@@ -16,7 +16,7 @@ SELECT
    WHEN platform = 'squarespace' THEN 'Squarespace'
    WHEN platform = 'x-wix-request-id' THEN 'Wix'
    WHEN platform = 'x-shopify-stage' THEN 'Shopify'
-   WHEN platform = 'x-now-id' THEN 'ZEIT Now'
+   WHEN platform = 'x-now-id' AND platform <> 'x-now-instance' THEN 'ZEIT Now'
    WHEN platform = 'flywheel' THEN 'Flywheel'
    WHEN platform = 'weebly' THEN 'Weebly'
    ELSE NULL

--- a/ttfb.sql
+++ b/ttfb.sql
@@ -16,7 +16,7 @@ SELECT
    WHEN platform = 'squarespace' THEN 'Squarespace'
    WHEN platform = 'x-wix-request-id' THEN 'Wix'
    WHEN platform = 'x-shopify-stage' THEN 'Shopify'
-   WHEN platform = 'x-now-id' AND platform <> 'x-now-instance' THEN 'ZEIT Now'
+   WHEN platform = 'x-now-id' AND secondary <> 'x-now-instance' THEN 'ZEIT Now'
    WHEN platform = 'flywheel' THEN 'Flywheel'
    WHEN platform = 'weebly' THEN 'Weebly'
    ELSE NULL
@@ -32,7 +32,10 @@ FROM
 JOIN
   (SELECT _TABLE_SUFFIX AS client, url, REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)),
       '(seravo|x-kinsta-cache|automattic.com/jobs|x-ah-environment|x-pantheon-styx-hostname|wpe-backend|hubspot|192fc2e7e50945beb8231a492d6a8024|x-github-request|alproxy|netlify|x-lw-cache|squarespace|x-wix-request-id|x-shopify-stage|x-now-id|flywheel|weebly)')
-    AS platform
+    AS platform,
+  (SELECT _TABLE_SUFFIX AS client, url, REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)),
+      '(x-now-instance)')
+    AS secondary
   FROM `httparchive.summary_requests.2019_06_01_*`)
 ON
   client = IF(form_factor.name = 'desktop', 'desktop', 'mobile') AND

--- a/ttfb.sql
+++ b/ttfb.sql
@@ -16,7 +16,7 @@ SELECT
    WHEN platform = 'squarespace' THEN 'Squarespace'
    WHEN platform = 'x-wix-request-id' THEN 'Wix'
    WHEN platform = 'x-shopify-stage' THEN 'Shopify'
-   WHEN platform = 'x-now-id' AND secondary <> 'x-now-instance' THEN 'ZEIT Now'
+   WHEN platform = 'x-now-cache' THEN 'ZEIT Now'
    WHEN platform = 'flywheel' THEN 'Flywheel'
    WHEN platform = 'weebly' THEN 'Weebly'
    ELSE NULL
@@ -31,11 +31,8 @@ FROM
   UNNEST(experimental.time_to_first_byte.histogram.bin) AS ttfb
 JOIN
   (SELECT _TABLE_SUFFIX AS client, url, REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)),
-      '(seravo|x-kinsta-cache|automattic.com/jobs|x-ah-environment|x-pantheon-styx-hostname|wpe-backend|hubspot|192fc2e7e50945beb8231a492d6a8024|x-github-request|alproxy|netlify|x-lw-cache|squarespace|x-wix-request-id|x-shopify-stage|x-now-id|flywheel|weebly)')
-    AS platform,
-  (SELECT _TABLE_SUFFIX AS client, url, REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)),
-      '(x-now-instance)')
-    AS secondary
+      '(seravo|x-kinsta-cache|automattic.com/jobs|x-ah-environment|x-pantheon-styx-hostname|wpe-backend|hubspot|192fc2e7e50945beb8231a492d6a8024|x-github-request|alproxy|netlify|x-lw-cache|squarespace|x-wix-request-id|x-shopify-stage|x-now-cache|flywheel|weebly)')
+    AS platform
   FROM `httparchive.summary_requests.2019_06_01_*`)
 ON
   client = IF(form_factor.name = 'desktop', 'desktop', 'mobile') AND


### PR DESCRIPTION
There are significant speed improvements between Now 1.0 and Now 2.0. In particular, cold-start times are drastically reduced and static pages are encouraged for the index page for example.

~~Both versions respond with a `x-now-id` but only Now 1.0 responds with a `x-now-instance` header.~~

~~I believe this query won't work as-is since I need to check all the headers at once instead of one at at time 🤔~~

~~I added another column called `secondary` to exclude the Now 1.0 deployments.~~

Updated to use `x-now-cache` header.