### PR TITLE
Detect WP Engine using X-Powered-By header

### DIFF
--- a/ttfb.sql
+++ b/ttfb.sql
@@ -6,6 +6,7 @@ SELECT
    WHEN platform = 'x-ah-environment' THEN 'Acquia'
    WHEN platform = 'x-pantheon-styx-hostname' THEN 'Pantheon'
    WHEN platform = 'wpe-backend' THEN 'WP Engine'
+   WHEN platform = 'wp engine' THEN 'WP Engine'
    WHEN platform = 'x-kinsta-cache' THEN 'Kinsta'
    WHEN platform = 'hubspot' THEN 'HubSpot'
    WHEN platform = 'b7440e60b07ee7b8044761568fab26e8' THEN 'SiteGround'
@@ -34,7 +35,7 @@ FROM
   UNNEST(experimental.time_to_first_byte.histogram.bin) AS ttfb
 JOIN
   (SELECT _TABLE_SUFFIX AS client, url, REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)),
-      '(seravo|x-kinsta-cache|automattic.com/jobs|x-ah-environment|x-pantheon-styx-hostname|wpe-backend|hubspot|b7440e60b07ee7b8044761568fab26e8|624d5be7be38418a3e2a818cc8b7029b|6b7412fb82ca5edfd0917e3957f05d89|x-github-request|alproxy|netlify|x-lw-cache|squarespace|x-wix-request-id|x-shopify-stage|x-now-cache|flywheel|weebly|dps/)')
+      '(seravo|x-kinsta-cache|automattic.com/jobs|x-ah-environment|x-pantheon-styx-hostname|wpe-backend|wp engine|hubspot|b7440e60b07ee7b8044761568fab26e8|624d5be7be38418a3e2a818cc8b7029b|6b7412fb82ca5edfd0917e3957f05d89|x-github-request|alproxy|netlify|x-lw-cache|squarespace|x-wix-request-id|x-shopify-stage|x-now-cache|flywheel|weebly|dps/)')
     AS platform
   FROM `httparchive.summary_requests.2019_09_01_*`
   WHERE firstHtml)


### PR DESCRIPTION
In December 2019, WP Engine added the `X-Powered-By: WP Engine` response header and removed the `wpe-backend: *` header.

I left the old header in this query so that it can still be used with older datasets.