### PR TITLE
Improved detection of Automattic/WordPress.com

### DIFF
--- a/ttfb.sql
+++ b/ttfb.sql
@@ -4,6 +4,7 @@ SELECT
    WHEN platform = 'seravo' THEN 'Seravo'
    WHEN platform = 'automattic.com/jobs' THEN 'Automattic'
    WHEN platform = 'wpvip.com/careers' THEN 'Automattic'
+   WHEN platform = 'wordpress.com' THEN 'Automattic'
    WHEN platform = 'x-ah-environment' THEN 'Acquia'
    WHEN platform = 'x-pantheon-styx-hostname' THEN 'Pantheon'
    WHEN platform = 'wpe-backend' THEN 'WP Engine'
@@ -36,7 +37,7 @@ FROM
   UNNEST(experimental.time_to_first_byte.histogram.bin) AS ttfb
 JOIN
   (SELECT _TABLE_SUFFIX AS client, url, REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)),
-      '(seravo|x-kinsta-cache|automattic.com/jobs|wpvip.com/careers|x-ah-environment|x-pantheon-styx-hostname|wpe-backend|wp engine|hubspot|b7440e60b07ee7b8044761568fab26e8|624d5be7be38418a3e2a818cc8b7029b|6b7412fb82ca5edfd0917e3957f05d89|x-github-request|alproxy|netlify|x-lw-cache|squarespace|x-wix-request-id|x-shopify-stage|x-vercel-id|flywheel|weebly|dps/)')
+      '(seravo|x-kinsta-cache|automattic.com/jobs|wpvip.com/careers|wordpress.com|x-ah-environment|x-pantheon-styx-hostname|wpe-backend|wp engine|hubspot|b7440e60b07ee7b8044761568fab26e8|624d5be7be38418a3e2a818cc8b7029b|6b7412fb82ca5edfd0917e3957f05d89|x-github-request|alproxy|netlify|x-lw-cache|squarespace|x-wix-request-id|x-shopify-stage|x-vercel-id|flywheel|weebly|dps/)')
     AS platform
   FROM `httparchive.summary_requests.2020_05_01_*`
   WHERE firstHtml)


### PR DESCRIPTION
Parts of the WordPress.com infrastructure do not include the `automattic.com/jobs|wpvip.com/careers` response headers.  Those parts have started including `host-header: WordPress.com` though.  This patch updates the header query to look for `wordpress.com`, and then includes that in the Automattic group.