### PR TITLE
Fix background gradient for Safari

### DIFF
--- a/style.css
+++ b/style.css
@@ -180,7 +180,7 @@ header h2 {
 
 #container {
     min-height: 595px;
-    background: radial-gradient(at center top, #fff, transparent 55%)
+    background: radial-gradient(at center top, #fff, rgba(255,255,255,0) 55%)
 }
 
 .inner {


### PR DESCRIPTION
Safari has a [different behaviour for gradients using the transparent keyword](https://bugs.webkit.org/show_bug.cgi?id=150940). To workaround it, let's be very explicit about the flavour of transparent we want.

## Before

<img alt="Before" src="https://user-images.githubusercontent.com/3653/125635910-11d25336-7175-4342-b1b9-bb88a4cdf718.png">


## After

<img alt="After" src="https://user-images.githubusercontent.com/3653/125636029-bf773277-3b77-4686-b3c3-aad7581bf147.png">